### PR TITLE
Correct hotkey command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,6 @@ fisher install eth-p/fish-plugin-sudo
 The <kbd>Ctrl+S</kbd> hotkey is not added by default. In order to bind the hotkey, add the following to your `config.fish` file:
 
 ```fish
-bind \cs '__ethp_commandline_toggle_sudo.fish'
+bind \cs '__ethp_commandline_toggle_sudo'
 ```
 


### PR DESCRIPTION
According to [this issue](https://github.com/eth-p/fish-plugin-sudo/issues/2#issuecomment-1206951803), the correct command for the hotkey is `bind \cs '__ethp_commandline_toggle_sudo'`.

